### PR TITLE
Adds the `customFormat` parameter to set the group and decimals separators.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.1.0
+- Adds the `customFormat` parameter to set the group and decimals separators. [Issue #4](https://github.com/Zmetser/angular-currency-filter/issues/4)
+
 # 2.0.0
 - **Breaking** If the amount is not a number, the formatter defaults to 0 instead of empty string. [Issue #5](https://github.com/Zmetser/angular-currency-filter/issues/5)
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2013 Oliver Kovacs
+Copyright (c) 2013-2016 Oliver Kovacs
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/README.md
+++ b/README.md
@@ -13,19 +13,20 @@ When no currency symbol is provided, default symbol for current locale is used.
 Overwrites angular's default currency filter if module: `currencyFilter` is injected. *(complete example in the Example section)*
 
 ### In HTML Template Binding
-    {{ currency_expression | currency[:symbol[:fractionSize[:suffixSymbol]]] }}
+    {{ currency_expression | currency:symbol[:fractionSize[:suffixSymbol[:customFormat]]] }}
 
 ### In JavaScript
-    $filter('currency')(amount[, symbol[, fractionSize[, suffixSymbol]]])
+    $filter('currency')(amount, symbol[, fractionSize[, suffixSymbol[, customFormat]]])
 
 #### Paramaters
 
-Param                   | Type    | Details
-:---------------------- | :------ | :------
-amount                  | number  | input to filter
-symbol (optional)       | string  | Currency symbol or identifier to be displayed.
-fractionSize (optional) | number  | Number of decimal places to round the number to. If this is not provided then the fraction size is computed from the current locale's number formatting pattern. In the case of the default locale, it will be 3.
-suffixSymbol (optional) | boolean | If set to true the currency symbol will be placed after the amount.
+Param         | Type    | Details
+:-----------  | :------ | :------
+amount        | number  | Input to filter.
+symbol        | string  | Currency symbol or identifier to be displayed. Falls back to [ng.$locale](https://code.angularjs.org/1.2.1/docs/api/ng.$locale).
+fractionSize  | number  | Number of decimal places to round the number to. Falls back to [ng.$locale](https://code.angularjs.org/1.2.1/docs/api/ng.$locale)
+suffixSymbol  | boolean | If set to true the currency symbol will be placed after the amount.
+customFormat  | object  | Customize group and decimal separators (`GROUP_SEP`, `DECIMAL_SEP`) Both falls back to [ng.$locale](https://code.angularjs.org/1.2.1/docs/api/ng.$locale).
 
 #### Returns
 
@@ -33,8 +34,13 @@ String: Formatted number.
 
 ### Use cases
 
+    var formats = {
+      GROUP_SEP: ' ',
+      DECIMAL_SEP: ','
+    };
+
     // With all parameters
-    expect(currency(1234.4239, '€', 0, true)).toEqual('1,234€');
+    expect(currency(1234.4239, '€', 1, true, formats)).toEqual('1 234,4€');
 
     // With missing fraction size
     expect(currency(1234.4239, '€', true)).toEqual('1,234.42€');
@@ -45,18 +51,21 @@ String: Formatted number.
     // Only with symbol
     expect(currency(1234.4239, '$')).toEqual('$1,234.42');
 
+    // Only with custom group and decimal separators
+    expect(currency(1234.4239, formats)).toEqual('$1 234,42');
+
 ### Example
 
 #### HTML Template Binding
 
-    <span ng-bind="price | currency:'€':true"></span>
+    <span ng-bind="price | currency:'€':true"></span> <!-- 1234.42€ -->
    
 #### JavaScript 
 
     angular.module('app', ['currencyFilter']).
         controller('Ctrl', function ( $scope, $filter ) {
             var currency = $filter('currency');
-            $scope.price = currency(1234.4239, '€', 0, true);
+            $scope.price = currency(1234.4239, '€', 0, true); // 1234€
         });
 
 
@@ -84,3 +93,7 @@ Don't forget to add `currencyFilter` module to your app's dependecies.
 ### Build
 
     $ grunt build
+
+## Compatibility
+
+Functionality verified with unit test with angular versions from `v1.2.1` to `v1.4.9`.

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-currency-filter",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "authors": [
     "Oliver Kovacs <zee@thezee.hu>"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-currency-filter",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Extend angular's built in currency filter.",
   "main": "./src/currency-filter.js",
   "directories": {

--- a/src/currency-filter.js
+++ b/src/currency-filter.js
@@ -14,9 +14,10 @@
       var pattern = formats.PATTERNS[1];
       // https://github.com/angular/angular.js/pull/3642
       formats.DEFAULT_PRECISION = angular.isUndefined(formats.DEFAULT_PRECISION) ? 2 : formats.DEFAULT_PRECISION;
-      return function ( amount, currencySymbol, fractionSize, suffixSymbol ) {
+      return function ( amount, currencySymbol, fractionSize, suffixSymbol, customFormat ) {
         if ( !angular.isNumber(amount) ) { amount = 0; }
-        if ( angular.isUndefined(currencySymbol) ) { currencySymbol = formats.CURRENCY_SYM; }
+        if ( angular.isObject(currencySymbol) ) { customFormat = currencySymbol; }
+        if ( angular.isUndefined(currencySymbol) || angular.isObject(currencySymbol) ) { currencySymbol = formats.CURRENCY_SYM; }
         var isNegative = amount < 0;
         var parts = [];
 
@@ -26,11 +27,24 @@
 
         amount = Math.abs(amount);
 
+        var groupSep = customFormat && angular.isString(customFormat.GROUP_SEP) ? customFormat.GROUP_SEP : formats.GROUP_SEP;
+        var decimalSep = customFormat && angular.isString(customFormat.DECIMAL_SEP) ? customFormat.DECIMAL_SEP : formats.DECIMAL_SEP;
         var number = numberFilter( amount, fractionSize );
 
+        var formattedNumber = [];
+        for (var i = 0; i < number.length; i++) {
+          if (number[i] === formats.GROUP_SEP)
+            formattedNumber.push(groupSep);
+          else if (number[i] === formats.DECIMAL_SEP)
+            formattedNumber.push(decimalSep);
+          else
+            formattedNumber.push(number[i]);
+        }
+        formattedNumber = formattedNumber.join('');
+
         parts.push(isNegative ? pattern.negPre : pattern.posPre);
-        parts.push(!suffixSymbol ? currencySymbol : number);
-        parts.push(suffixSymbol ? currencySymbol : number);
+        parts.push(!suffixSymbol ? currencySymbol : formattedNumber);
+        parts.push(suffixSymbol ? currencySymbol : formattedNumber);
         parts.push(isNegative ? pattern.negSuf : pattern.posSuf);
 
         return parts.join('').replace(/\u00A4/g, '');

--- a/test/unit/currency-filter.spec.js
+++ b/test/unit/currency-filter.spec.js
@@ -52,18 +52,82 @@ describe('currency', function() {
       expect(currency(1234.42)).toEqual('$1,234.42');
     });
 
-    it('should test API', function() {
+  });
+
+  describe('test API consistency', function() {
+    var groupSep = {GROUP_SEP: ' '};
+
+    it('with common use cases', function () {
       expect(currency(1234.42, '€', true)).toEqual('1,234.42€');
       expect(currency(1234, '$', 0)).toEqual('$1,234');
     });
 
+    it('with no amount', function () {
+      expect(currency()).toEqual('$0.00');
+      expect(currency(null, 'USD$')).toEqual('USD$0.00');
+      expect(currency(null, 'USD$', 1)).toEqual('USD$0.0');
+      expect(currency(null, '€', 1, true)).toEqual('0.0€');
+      expect(currency(null, '€', true)).toEqual('0.00€');
+    });
+
+    describe('group separator as', function () {
+      it('second param', function () {
+        expect(currency(1000, groupSep)).toEqual('$1 000.00');
+      });
+
+      it('last param', function () {
+        expect(currency(1000, '€', 1, true, groupSep)).toEqual('1 000.0€');
+      });
+    });
+  });
+
+  describe('group separator', function() {
+
+    it('should fall back to default angluar locale', function () {
+      expect(currency(1234.42)).toEqual('$1,234.42');
+    });
+
+    it('should change the group separator to dash', function () {
+      var groupSep = {GROUP_SEP: ' '};
+
+      expect(currency(123.42, groupSep)).toEqual('$123.42');
+      expect(currency(1234.42, groupSep)).toEqual('$1 234.42');
+      expect(currency(123456789.42, groupSep)).toEqual('$123 456 789.42');
+    });
+
+    it('should remove the group separator', function () {
+      var groupSep = {GROUP_SEP: ''};
+
+      expect(currency(123.42, groupSep)).toEqual('$123.42');
+      expect(currency(1234.42, groupSep)).toEqual('$1234.42');
+      expect(currency(123456789.42, groupSep)).toEqual('$123456789.42');
+    });
+
+  });
+
+  describe('decimal separator', function() {
+
+    it('should fall back to default angluar locale', function () {
+      expect(currency(1234.42)).toEqual('$1,234.42');
+    });
+
+    it('should change the group separator to dash', function () {
+      var decimalSep = {DECIMAL_SEP: ','};
+
+      expect(currency(1.42, decimalSep)).toEqual('$1,42');
+    });
   });
 
   describe('demo', function() {
 
     it('should verify demo use cases', function() {
+      var formats = {
+        GROUP_SEP: ' ',
+        DECIMAL_SEP: ','
+      };
+
       // With all parameters
-      expect(currency(1234.4239, '€', 0, true)).toEqual('1,234€');
+      expect(currency(1234.4239, '€', 1, true, formats)).toEqual('1 234,4€');
 
       // With missing fraction size
       expect(currency(1234.4239, '€', true)).toEqual('1,234.42€');
@@ -73,6 +137,9 @@ describe('currency', function() {
 
       // Only with symbol
       expect(currency(1234.4239, '$')).toEqual('$1,234.42');
+
+      // Only with custom group and decimal separators
+      expect(currency(1234.4239, formats)).toEqual('$1 234,42');
     });
 
   });


### PR DESCRIPTION
Fixes https://github.com/Zmetser/angular-currency-filter/issues/4

 